### PR TITLE
Code Block Formatting

### DIFF
--- a/src/styles/prism/language-tab.css
+++ b/src/styles/prism/language-tab.css
@@ -20,6 +20,10 @@
   color: white;
 }
 
+[data-language="text"] {
+  padding-top: 1em;
+}
+
 /* Language Styles */
 
 [data-language="javascript"]::before {

--- a/src/styles/prism/line-highlight.css
+++ b/src/styles/prism/line-highlight.css
@@ -27,7 +27,7 @@
  */
 .gatsby-highlight pre[class*='language-'] {
   margin: 0;
-  padding: 0;
+  padding: 0 1em 0 0;
   overflow: initial;
   float: left; /* 1 */
   min-width: 100%; /* 2 */

--- a/src/styles/prism/line-numbers.css
+++ b/src/styles/prism/line-numbers.css
@@ -18,7 +18,7 @@
 }
 
 .gatsby-highlight pre[class*='language-'].line-numbers {
-  padding: 0;
+  padding: 0 1em 0 0;
   padding-left: 2.8em;
   overflow: initial;
 }

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -51,6 +51,13 @@ const Content = styled.article`
       margin-top: 0;
     }
   }
+
+  // CALLOUTS
+  aside {
+    p {
+      margin-bottom: 0;
+    }
+  }
 `;
 
 const SharePost = styled.div`


### PR DESCRIPTION
* Remove top padding when there is no explicit language banner
* Add left-hand padding when code block scrolls off-screen
* Remove bottom padding when Callout uses Markdown

Fixes #8